### PR TITLE
Add help output to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 PKGDIR = pkg
 
-default: build
+define USAGE
+Usage instructions:
+    make lint                 runs jshint on the source code
+    make test                 runs the test suite using phantomjs
+    make build                creates a production (minified) build
+    make help                 displays this message
+endef
+export USAGE
+
+default: help
+
+help:
+	@echo "$$USAGE"
 
 pkgdir:
 	@rm -rf $(PKGDIR)
@@ -22,4 +34,4 @@ lint:
 
 build: concat minify
 
-.PHONY: build test lint
+.PHONY: help pkgdir concat minify test lint build

--- a/README
+++ b/README
@@ -73,6 +73,11 @@ Development
 It's very simple, hack on the code, ensure the lint and tests pass and submit
 a pull request. Rinse and repeat.
 
+There is a Makefile containing useful development tools. The available commands
+can be listed by running:
+
+    $ make
+
 To install the developer packages you'll need node and npm installed on your
 machine. Then run:
 


### PR DESCRIPTION
This is now output when running `make` on its own. It was the first thing I ran when pulling the project and I wanted to run the tests.

```
$ make
Usage instructions:
    make lint                 runs jshint on the source code
    make test                 runs the test suite using phantomjs
    make build                creates a production (minified) build
    make help                 displays this message
```
