### PR TITLE
Clarify usage of maxHeight option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Truncate.js currently depends on jQuery. There are two ways to use Truncate.js:
 
 ## Options
 
-- `lineHeight`: **Required**. The text line height.
+- `lineHeight`: **Required**. The text line height (in px).
 - `lines`: The number of line maximum. _default: 1_
 - `ellipsis`: Text content to add at the truncation point. _default: …_
 - `showMore`: HTML to insert at the truncation point. Useful for a "Show More" button. _default: ""_

--- a/truncate.js
+++ b/truncate.js
@@ -22,7 +22,7 @@
    * $clipNode - The jQuery node to insert right after the truncation point.
    * options   - An object containing:
    *             ellipsis  - The ellipsis string to append at the end of the truncation.
-   *             maxHeight - The maximum height for the root node.
+   *             maxHeight - The maximum height for the root node (in px).
    *
    * Returns true if truncation happened, false otherwise.
    */
@@ -75,7 +75,7 @@
    * $clipNode - The jQuery node to insert right after the truncation point.
    * options   - An object containing:
    *             ellipsis  - The ellipsis string to append at the end of the truncation.
-   *             maxHeight - The maximum height for the root node.
+   *             maxHeight - The maximum height for the root node (in px).
    *
    * Returns true if truncation happened, false otherwise.
    */
@@ -118,7 +118,7 @@
    * $clipNode - The jQuery node to insert right after the truncation point.
    * options   - An object containing:
    *             ellipsis  - The ellipsis string to append at the end of the truncation.
-   *             maxHeight - The maximum height for the root node.
+   *             maxHeight - The maximum height for the root node (in px).
    *
    * Returns true if truncation happened, false otherwise.
    */


### PR DESCRIPTION
This may be a bit pedantic but I've used your plugin in a few of my projects and I always get confused about what unit to specify the max height in and have to look through the source code to work out that it should be in pixels. I thought it might help other people to add the pixel unit to the README file and to the source documentation to make it a little clearer.

Thanks for writing such a helpful plugin :smile: 